### PR TITLE
Fixes to have same behaviour like SymSpellpy

### DIFF
--- a/library/src/commonMain/kotlin/com/darkrockstudios/symspellkt/common/SpellHelper.kt
+++ b/library/src/commonMain/kotlin/com/darkrockstudios/symspellkt/common/SpellHelper.kt
@@ -15,19 +15,15 @@ object SpellHelper {
 		editFactor: Double,
 	): Set<String> {
 		val deletedWords: MutableSet<String> = mutableSetOf()
+		var newKey = key
 		if (key.length <= maxEditDistance) {
 			deletedWords.add("")
 		}
 		if (key.length > maxEditDistance) {
-			deletedWords
-				.add(
-					key.substring(
-						0,
-						if (prefixLength < key.length) prefixLength else key.length
-					)
-				)
+			newKey = key.substring(0, if (prefixLength < key.length) prefixLength else key.length)
+			deletedWords.add(newKey)
 		}
-		return edits(key, 0.0, deletedWords, getEdistance(maxEditDistance, key.length, editFactor))
+		return edits(newKey, 0.0, deletedWords, getEdistance(maxEditDistance, newKey.length, editFactor))
 	}
 
 	private fun getEdistance(maxEditDistance: Double, length: Int, factor: Double): Double {

--- a/library/src/commonMain/kotlin/com/darkrockstudios/symspellkt/impl/SymSpellCheck.kt
+++ b/library/src/commonMain/kotlin/com/darkrockstudios/symspellkt/impl/SymSpellCheck.kt
@@ -364,21 +364,20 @@ class SymSpellCheck(
 
 		consideredSuggestions.add(curPhrase)
 		var maxEditDistance2 = maxEditDistance
-		val phrasePrefixLen: Int
+		var phrasePrefixLen: Int = phraseLen
 		val candidates: MutableList<String> = ArrayList()
 
 		if (phraseLen > spellCheckSettings.prefixLength) {
 			phrasePrefixLen = spellCheckSettings.prefixLength
 			candidates.add(curPhrase.substring(0, phrasePrefixLen))
 		} else {
-			phrasePrefixLen = phraseLen
+			candidates.add(curPhrase)
 		}
-		candidates.add(curPhrase)
 
 		while (candidates.isNotEmpty()) {
 			val candidate = candidates.removeAt(0)
 			val candidateLen = candidate.length
-			val lenDiff = phraseLen - candidateLen
+			val lenDiff = phrasePrefixLen - candidateLen
 
 			// Empty candidates cause a bunch of unnecessary suggestions and waste time.
 			// I think this is okay? If there are ever problems with single letter word


### PR DESCRIPTION
Hello, we're really looking forward to use your library but we found some differences to the current python implementation that we use.

* in SpellHelper: We think that you need to pass the changed key-string to the edit function and not the original key, because the maxEditDistance wouldn't catch.
* in SymSpellCheck: In SymSpellPy the original phrase isn't included in the candidates.

thank you for your work and we are looking forward to your feedback