### PR TITLE
Add option to prefer or not prefer quick distance calculation

### DIFF
--- a/SymSpellKt/src/commonMain/kotlin/com/darkrockstudios/symspellkt/common/SpellCheckSettings.kt
+++ b/SymSpellKt/src/commonMain/kotlin/com/darkrockstudios/symspellkt/common/SpellCheckSettings.kt
@@ -56,6 +56,12 @@ data class SpellCheckSettings(
 	 */
 	val editFactor: Double = 0.3,
 
+	/**
+	 * As a performance optimization we prefer a quick distance calculation for small maxEditDistances.
+	 * This could lead in some edgecases to a wrong result, but in most cases it leads to better performance.
+	 */
+	val preferQuickDistanceOnSmallEditDistance: Boolean = true,
+
 	val doKeySplit: Boolean = true,
 
 	val keySplitRegex: Regex = "\\s+".toRegex(),

--- a/SymSpellKt/src/commonMain/kotlin/com/darkrockstudios/symspellkt/impl/SymSpell.kt
+++ b/SymSpellKt/src/commonMain/kotlin/com/darkrockstudios/symspellkt/impl/SymSpell.kt
@@ -501,7 +501,7 @@ class SymSpell(
 							) {
 								continue
 							}
-							distance = if (maxEditDistance2 <= 2) {
+							distance = if (spellCheckSettings.preferQuickDistanceOnSmallEditDistance && maxEditDistance2 <= 2) {
 								// Try quick distance first for small edit distances
 								quickDistance(curPhrase, suggestion)
 									?: stringDistance.getDistance(curPhrase, suggestion, maxEditDistance2)


### PR DESCRIPTION
The newly added function "quickDistance" leads to problems in our spellchecking, because the result of the distance calculation is quiet different.

We would like to add an option to configure the usage of the quickDistance function. This would help us to keep the quality as it was before.